### PR TITLE
Fix library name and add AUTOMOC property

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,26 +1,26 @@
 cmake_minimum_required(VERSION 3.15)
 find_package(Qt5 COMPONENTS Bluetooth REQUIRED)
-set(CMAKE_AUTOMOC ON)
-add_library(libasteroid SHARED
-    watch.cpp 
-    watchconnection.cpp 
+add_library(asteroid SHARED
+    watch.cpp
+    watchconnection.cpp
     scanner.cpp
-    services/batteryservice.cpp 
+    services/batteryservice.cpp
     services/mediaservice.cpp
     services/notificationservice.cpp
     services/timeservice.cpp
     services/screenshotservice.cpp
-    services/weatherservice.cpp 
+    services/weatherservice.cpp
     services/service.cpp
 )
-target_compile_features(libasteroid PUBLIC cxx_std_17)
-target_compile_options(libasteroid PRIVATE -Wall -Wextra -pedantic -Werror)
-target_link_libraries(libasteroid PRIVATE Qt5::Bluetooth)
-target_include_directories(libasteroid 
+target_compile_features(asteroid PUBLIC cxx_std_17)
+set_target_properties(asteroid PROPERTIES AUTOMOC ON)
+target_compile_options(asteroid PRIVATE -Wall -Wextra -pedantic -Werror)
+target_link_libraries(asteroid PRIVATE Qt5::Bluetooth)
+target_include_directories(asteroid
     PUBLIC
         $<INSTALL_INTERFACE:.>
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
     PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR}/services
 )
-install(TARGETS libasteroid)
+install(TARGETS asteroid)


### PR DESCRIPTION
The library name had an extra "lib" prefix and was being produced as
liblibasteroid.  This fixes that error, removes some spurious end-of-line 
whitespace and also changes AUTOMOC ON to be a target property 
instead of global.