### PR TITLE
Add missing signal for volume control

### DIFF
--- a/src/services/mediaservice.cpp
+++ b/src/services/mediaservice.cpp
@@ -91,6 +91,10 @@ void MediaService::onCharacteristicChanged(const QLowEnergyCharacteristic &c, co
         case 0x3:
             emit pause();
             break;
+        case 0x4:
+            quint8 vol = data[1];
+            emit volume(vol);
+            break;
         }
     }
 }

--- a/src/services/mediaservice.h
+++ b/src/services/mediaservice.h
@@ -39,6 +39,7 @@ signals:
     bool next();
     bool play();
     bool pause();
+    bool volume(quint8);
 
 protected:
     void onServiceDiscovered() override;


### PR DESCRIPTION
The library was missing the volume control signal which has now been
added and tested.  This fixes issue #11.