### PR TITLE
Refactor notification service

### DIFF
--- a/src/services/notificationservice.cpp
+++ b/src/services/notificationservice.cpp
@@ -29,27 +29,11 @@ void NotificationService::onServiceDiscovered()
         emit ready();
 }
 
-bool NotificationService::insertNotification(QString packageName, unsigned int id, QString appName, QString icon, QString summary, QString body, Vibrate vibrate)
+bool NotificationService::insertNotification(QString packageName, unsigned int id, QString appName, QString icon, QString summary, QString body, QString vibrate)
 {
     if(m_service && m_updateChrc.isValid()) {
-        QString vibrateStr;
-        switch(vibrate) {
-        case Ringtone:
-            vibrateStr = "ringtone";
-            break;
-        case Strong:
-            vibrateStr = "strong";
-            break;
-        case Normal:
-            vibrateStr = "normal";
-            break;
-        case None:
-            vibrateStr = "none";
-            break;
-        }
-
         QByteArray data = QString("<insert><pn>%1</pn><id>%2</id><an>%3</an><ai>%4</ai><su>%5</su><bo>%6</bo><vb>%7</vb></insert>")
-                .arg(packageName, QString::number(id), appName, icon, summary, body, vibrateStr).toUtf8();
+                .arg(packageName, QString::number(id), appName, icon, summary, body, vibrate).toUtf8();
 
         m_service->writeCharacteristic(m_updateChrc, data, QLowEnergyService::WriteWithoutResponse);
         return true;

--- a/src/services/notificationservice.cpp
+++ b/src/services/notificationservice.cpp
@@ -66,18 +66,3 @@ bool NotificationService::removeNotification(unsigned int id)
     } else
         return false;
 }
-
-void NotificationService::setVibration(const QString v)
-{
-  if(v == "Strong")
-    m_vibrate = Strong;
-  else if( v == "Normal")
-    m_vibrate = Normal;
-  else
-    m_vibrate = None;
-}
-
-NotificationService::Vibrate NotificationService::getVibration()
-{
-    return m_vibrate;
-}

--- a/src/services/notificationservice.h
+++ b/src/services/notificationservice.h
@@ -33,8 +33,6 @@ public:
 
     bool insertNotification(QString packageName, unsigned int id, QString appName, QString icon, QString summary, QString body, Vibrate vibrate);
     bool removeNotification(unsigned int id);
-    void setVibration(const QString v);
-    Vibrate getVibration();
 
 protected:
     void onServiceDiscovered() override;
@@ -43,7 +41,6 @@ protected:
 private:
     QLowEnergyCharacteristic m_updateChrc;
     QLowEnergyCharacteristic m_feedbackChrc;
-    Vibrate m_vibrate = Normal;
 };
 
 #endif // NOTIFICATIONSERVICE_H

--- a/src/services/notificationservice.h
+++ b/src/services/notificationservice.h
@@ -27,11 +27,11 @@ class NotificationService : public Service
     Q_OBJECT
 
 public:
-    enum Vibrate { Ringtone, Strong, Normal, None };
 
     NotificationService();
 
-    bool insertNotification(QString packageName, unsigned int id, QString appName, QString icon, QString summary, QString body, Vibrate vibrate);
+    // for vibrate, valid options are { "ringtone", "strong", "normal", "none" }
+    bool insertNotification(QString packageName, unsigned int id, QString appName, QString icon, QString summary, QString body, QString vibrate);
     bool removeNotification(unsigned int id);
 
 protected:


### PR DESCRIPTION
To accommodate refactoring the notification service as mentioned here, https://github.com/AsteroidOS/asteroidsyncservice/pull/50 first the underlying library must be refactored to remove the `setVibration() and `getVibration()` functions.  Next, a convenience function was added to simplify conversion from a string into the enum required for the library.