### PR TITLE
Introduce weather day

### DIFF
--- a/src/services/weatherservice.cpp
+++ b/src/services/weatherservice.cpp
@@ -87,3 +87,17 @@ bool WeatherService::setMaxTemps(QList<short> l)
     } else
         return false;
 }
+
+bool WeatherService::setWeatherDays(QList<WeatherDay> wd)
+{
+    QList<short> icons;
+    QList<short> minTemps;
+    QList<short> maxTemps;
+
+    for(int i = 0; i < wd.length() && i < 5; ++i) {
+        icons.push_back(wd[i].m_wxIcon);
+        minTemps.push_back(wd[i].m_loTemp);
+        maxTemps.push_back(wd[i].m_hiTemp);
+    }
+    return setIds(icons) && setMinTemps(minTemps) && setMaxTemps(maxTemps);
+}

--- a/src/services/weatherservice.h
+++ b/src/services/weatherservice.h
@@ -22,6 +22,15 @@
 
 #include "service.h"
 
+struct WeatherDay 
+{
+    short m_wxIcon = 0;
+    short m_loTemp = 0;
+    short m_hiTemp = 0;
+};
+
+Q_DECLARE_METATYPE(WeatherDay);
+
 class WeatherService : public Service
 {
     Q_OBJECT
@@ -33,6 +42,7 @@ public:
     bool setIds(QList<short> l);
     bool setMinTemps(QList<short> l);
     bool setMaxTemps(QList<short> l);
+    bool setWeatherDays(QList<WeatherDay> wd);
 
 protected:
     void onServiceDiscovered() override;


### PR DESCRIPTION
This adds a new structure `WeatherDay` which contains the icon code, the low temperature and the high temperature for a single day.  It then adds a new function, `bool WeatherService::setWeatherDays(QList<WeatherDay> wd)` which sets all of these parameters by calling the existing functions to set three arrays, one each for the icons, lows, and highs.  This is intended to make the calling code from `asteroidsyncservice` (which doesn't currently support weather data at all) both more logical and offering a narrower API.