### PR TITLE
Patch screenshot service to avoid crashing

### DIFF
--- a/src/services/screenshotservice.cpp
+++ b/src/services/screenshotservice.cpp
@@ -45,8 +45,12 @@ bool ScreenshotService::requestScreenshot()
 void ScreenshotService::onCharacteristicChanged(const QLowEnergyCharacteristic &c, const QByteArray &value)
 {
     if (c.uuid() == QBluetoothUuid(QString(SCREENSH_CON_UUID))) {
-        if(m_firstNotify) {
-            m_totalSize = (value[0] << 0 | value[1] << 8 | value[2] << 16 | value[3] << 24);
+        if(m_firstNotify && value.size() >= 4) {
+            m_totalSize = (
+                static_cast<unsigned>(value[0] & 0xff) << 0 | 
+                static_cast<unsigned>(value[1] & 0xff) << 8 | 
+                static_cast<unsigned>(value[2] & 0xff) << 16 | 
+                static_cast<unsigned>(value[3] & 0xff) << 24);
             m_totalData.resize(0);
             m_progress = 0;
             m_firstNotify = false;

--- a/src/services/screenshotservice.h
+++ b/src/services/screenshotservice.h
@@ -43,11 +43,11 @@ private:
     QLowEnergyCharacteristic m_reqChrc;
     QLowEnergyCharacteristic m_conChrc;
 
-    bool m_firstNotify;
+    bool m_firstNotify = true;
     bool m_downloading;
     QByteArray m_totalData;
     unsigned int m_progress;
-    unsigned int m_totalSize;
+    unsigned int m_totalSize = 1;
 };
 
 #endif // SCREENSHOTSERVICE_H


### PR DESCRIPTION
Sometimes the first packet received back from the watch is not the length or is not four bytes long.  This fixes both issues by explicitly setting variables in during construction of the service object.  It also fixes a latent bug that would cause incorrect size setting if any of the size bytes were greater than 0x7f and therefore interpreted as a signed integer and incorrectly extending the sign bit.

Signed-off-by: Ed Beroset <beroset@ieee.org>