### PR TITLE
Use WriteWithResponse for longer messages

### DIFF
--- a/src/services/mediaservice.cpp
+++ b/src/services/mediaservice.cpp
@@ -42,7 +42,7 @@ void MediaService::onServiceDiscovered()
 bool MediaService::setTitle(QString title)
 {
     if(m_service && m_titleChrc.isValid()) {
-        m_service->writeCharacteristic(m_titleChrc, title.toUtf8(), QLowEnergyService::WriteWithoutResponse);
+        m_service->writeCharacteristic(m_titleChrc, title.toUtf8(), QLowEnergyService::WriteWithResponse);
         return true;
     } else
         return false;
@@ -51,7 +51,7 @@ bool MediaService::setTitle(QString title)
 bool MediaService::setAlbum(QString album)
 {
     if(m_service && m_albumChrc.isValid()) {
-        m_service->writeCharacteristic(m_albumChrc, album.toUtf8(), QLowEnergyService::WriteWithoutResponse);
+        m_service->writeCharacteristic(m_albumChrc, album.toUtf8(), QLowEnergyService::WriteWithResponse);
         return true;
     } else
         return false;
@@ -60,7 +60,7 @@ bool MediaService::setAlbum(QString album)
 bool MediaService::setArtist(QString artist)
 {
     if(m_service && m_artistChrc.isValid()) {
-        m_service->writeCharacteristic(m_artistChrc, artist.toUtf8(), QLowEnergyService::WriteWithoutResponse);
+        m_service->writeCharacteristic(m_artistChrc, artist.toUtf8(), QLowEnergyService::WriteWithResponse);
         return true;
     } else
         return false;
@@ -70,7 +70,7 @@ bool MediaService::setPlaying(bool playing)
 {
     if(m_service && m_playingChrc.isValid()) {
         QByteArray val = playing ? QByteArray(1, 1) : QByteArray(1, 0);
-        m_service->writeCharacteristic(m_playingChrc, val, QLowEnergyService::WriteWithoutResponse);
+        m_service->writeCharacteristic(m_playingChrc, val, QLowEnergyService::WriteWithResponse);
         return true;
     } else
         return false;

--- a/src/services/notificationservice.cpp
+++ b/src/services/notificationservice.cpp
@@ -35,7 +35,7 @@ bool NotificationService::insertNotification(QString packageName, unsigned int i
         QByteArray data = QString("<insert><pn>%1</pn><id>%2</id><an>%3</an><ai>%4</ai><su>%5</su><bo>%6</bo><vb>%7</vb></insert>")
                 .arg(packageName, QString::number(id), appName, icon, summary, body, vibrate).toUtf8();
 
-        m_service->writeCharacteristic(m_updateChrc, data, QLowEnergyService::WriteWithoutResponse);
+        m_service->writeCharacteristic(m_updateChrc, data, QLowEnergyService::WriteWithResponse);
         return true;
     } else
         return false;
@@ -45,7 +45,7 @@ bool NotificationService::removeNotification(unsigned int id)
 {
     if(m_service && m_updateChrc.isValid()) {
         QByteArray data = QString("<removed><id>%1</id></removed>").arg(id).toUtf8();
-        m_service->writeCharacteristic(m_updateChrc, data, QLowEnergyService::WriteWithoutResponse);
+        m_service->writeCharacteristic(m_updateChrc, data, QLowEnergyService::WriteWithResponse);
         return true;
     } else
         return false;

--- a/src/services/weatherservice.cpp
+++ b/src/services/weatherservice.cpp
@@ -34,7 +34,7 @@ void WeatherService::onServiceDiscovered()
 bool WeatherService::setCity(QString city)
 {
     if(m_service && m_cityChrc.isValid()) {
-        m_service->writeCharacteristic(m_cityChrc, city.toUtf8(), QLowEnergyService::WriteWithoutResponse);
+        m_service->writeCharacteristic(m_cityChrc, city.toUtf8(), QLowEnergyService::WriteWithResponse);
         return true;
     } else
         return false;
@@ -50,7 +50,7 @@ bool WeatherService::setIds(QList<short> l)
             data[(2*i)+1] = (quint8)(l[i]);
         }
 
-        m_service->writeCharacteristic(m_idsChrc, data, QLowEnergyService::WriteWithoutResponse);
+        m_service->writeCharacteristic(m_idsChrc, data, QLowEnergyService::WriteWithResponse);
         return true;
     } else
         return false;
@@ -66,7 +66,7 @@ bool WeatherService::setMinTemps(QList<short> l)
             data[(2*i)+1] = (quint8)(l[i]);
         }
 
-        m_service->writeCharacteristic(m_minTempsChrc, data, QLowEnergyService::WriteWithoutResponse);
+        m_service->writeCharacteristic(m_minTempsChrc, data, QLowEnergyService::WriteWithResponse);
         return true;
     } else
         return false;
@@ -82,7 +82,7 @@ bool WeatherService::setMaxTemps(QList<short> l)
             data[(2*i)+1] = (quint8)(l[i]);
         }
 
-        m_service->writeCharacteristic(m_maxTempsChrc, data, QLowEnergyService::WriteWithoutResponse);
+        m_service->writeCharacteristic(m_maxTempsChrc, data, QLowEnergyService::WriteWithResponse);
         return true;
     } else
         return false;


### PR DESCRIPTION
This fixes https://github.com/AsteroidOS/libasteroid/issues/21 by only using WriteWitoutResponse for two messages: the time set message and the screenshot request message.  The reason is that the Qt documentation states that if WriteWithoutResponse is used, the payload can be no more than 20 bytes but this is often not the case for most of these messages.